### PR TITLE
Fix broken path in test_BNT script

### DIFF
--- a/BNT/examples/static/mixexp2.m
+++ b/BNT/examples/static/mixexp2.m
@@ -50,7 +50,7 @@ end
 
 
 
-load('/examples/static/Misc/mixexp_data.txt', '-ascii');        
+load(fullfile(bntRoot(),'BNT','examples','static','Misc','mixexp_data.txt'), '-ascii');        
 % Just use 1/10th of the data, to speed things up
 data = mixexp_data(1:10:end, :);
 %data = mixexp_data;

--- a/BNT/test_BNT.m
+++ b/BNT/test_BNT.m
@@ -101,6 +101,8 @@ if exist('@jtree_sparse_inf_engine/init_pot','file')
   water2
 end
 
+disp('BNT testing completed successfully.')
+
 %find . -path '*.m' -exec wc -l {} \; | ~/count.pl
 
 % we cannot use tic;toc to time test_BNT, since functions within this script


### PR DESCRIPTION
running test_BNT was giving an error when trying to load the data for mixexp2